### PR TITLE
Revert "Update index.js to fix issue with tooltip not displaying for bar charts"

### DIFF
--- a/visualizations/multi-timeseries-series/index.js
+++ b/visualizations/multi-timeseries-series/index.js
@@ -1008,7 +1008,7 @@ function AlignedTimeseries(props) {
                 label={xLabel}
                 dataKey="x"  
                 type="category" 
-                allowDuplicatedCategory={true} 
+                allowDuplicatedCategory={false} 
                 interval="preserveStart"  
                 tick={{fill: tickColor}}
                 style={{


### PR DESCRIPTION
Reverts newrelic-experimental/nr1-viz-historical-compare#23
Seems to break some views, need to find another way to hide the line chart when using bar chart
